### PR TITLE
Fixed a typo in the artifacts' names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ This tool helps us to solve such common dependency-hell problem like *"Where thi
 
 #### Running from the latest release
 1. [Download current release](https://github.com/avast/gradle-dependencies-viewer/files/790796/gradle-dependencies-viewer-1.0.0.zip)
-2. Extract zip file and use ```/bin/gradle-dependency-viewer.bat``` (Win) or ```/bin/gradle-dependency-viewer``` (Linux)
+2. Extract zip file and use ```/bin/gradle-dependencies-viewer.bat``` (Win) or ```/bin/gradle-dependencies-viewer``` (Linux)
 
 **OR**
 
 #### Running from sources
 1. Build binaries ```gradle build``` or ```gradlew.bat build```  or
-2. Extract ```build/distributions/gradle-dependency-viewer-x.x.x.zip``` (or .tar on Linux)
-3. Run script ```/bin/gradle-dependency-viewer.bat``` (Win) or ```/bin/gradle-dependency-viewer``` (Linux)
-4. **OR** Run single fat jar ```java -jar gradle-dependency-viewer-1.0.0.jar --server.port=8090```
- - File ```gradle-dependency-viewer-x.x.x.jar``` is located in ```build/libs```.
+2. Extract ```build/distributions/gradle-dependencies-viewer-x.x.x.zip``` (or .tar on Linux)
+3. Run script ```/bin/gradle-dependencies-viewer.bat``` (Win) or ```/bin/gradle-dependencies-viewer``` (Linux)
+4. **OR** Run single fat jar ```java -jar gradle-dependencies-viewer-1.0.0.jar --server.port=8090```
+ - File ```gradle-dependencies-viewer-x.x.x.jar``` is located in ```build/libs```.
 5. Open [http://localhost:8090/](http://localhost:8090/) in your web browser.
  - Default port value has been set to 8090.
 


### PR DESCRIPTION
Updated the README according to the latest artifact names ('gradle-dependency-viewer' => 'gradle-dependencies-viewer').