### PR TITLE
Fixes parsing multi project dependencies task output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        maven { url 'https://artifactory.int.avast.com/artifactory/maven' }
         maven { url 'http://repo.spring.io/libs-release' }
         maven { url 'http://repo.spring.io/plugins-release' }
     }
@@ -44,7 +43,6 @@ springBoot {
 
 
 repositories {
-    maven { url 'https://artifactory.int.avast.com/artifactory/maven' }
     maven { url 'http://repo.spring.io/libs-release' }
     maven { url 'http://repo.spring.io/plugins-release' }
 }

--- a/src/main/java/com/avast/server/libver/service/impl/GradleParser.java
+++ b/src/main/java/com/avast/server/libver/service/impl/GradleParser.java
@@ -49,14 +49,15 @@ public class GradleParser {
             } else {
                 projectDepsData = data.substring(projectIndex);
             }
-            fillSourceSets(projectIndex, subproject, projectDepsData);
+            fillSourceSets(subproject, projectDepsData);
             projectIndex = projectMatcher.end();
         }
         return gradleDepsDescriptor;
     }
 
-    private void fillSourceSets(int sourceIndex, Subproject subproject, String projectDepsData) throws ParseException {
+    private void fillSourceSets(Subproject subproject, String projectDepsData) throws ParseException {
         final Matcher matcher = TREE_LINE.matcher(projectDepsData);
+        int sourceIndex = 0;
         while (matcher.find(sourceIndex)) {
             final int treeLineStart = matcher.start();
             final int titleIndex = projectDepsData.lastIndexOf("\n\n", treeLineStart);


### PR DESCRIPTION
The source index was set to != 0 in case of following subprojects, but projectDepsData already points to the start of the subproject.